### PR TITLE
Update Text.ContainsAny.m

### DIFF
--- a/Text.ContainsAny.m
+++ b/Text.ContainsAny.m
@@ -15,7 +15,7 @@ in
 List.AnyTrue(
 	List.Generate(
 		()=>[i=0],
-		each [i] <= count,
+		each [i] < count,
 		each [i=[i]+1],
 		each Text.Contains(str,needles{[i]})
 	)


### PR DESCRIPTION
Assume that needles = {"A".."Z"}, List.Count gives 26. 
However loop on i starts from 0, while <= count. 
Case "=count" will take 27th element, which doesn't exist in needles.