### PR TITLE
Fix case mismatch in module name

### DIFF
--- a/CrossUsage.pq
+++ b/CrossUsage.pq
@@ -1,5 +1,5 @@
 ﻿let
-    Table.CrossJoin = Load("Table.Crossjoin"),
+    Table.CrossJoin = Load("Table.CrossJoin"),
     Tokens = Table.RenameColumns(Table.FromList(Record.FieldNames(#shared)), {"Column1", "Token"}),
     AddAlts = Table.AddColumn(Tokens, "TokenAlt", each Text.Replace([Token], "_", ".")),
     Crossed = Table.CrossJoin(AddAlts, UdfContents),


### PR DESCRIPTION
The argument of Load() function did not match the filename of *.pq module.

This would not usually result in any error when loading from filesystem
(Windows paths are case-insensitive), but if another version of loader
would be used, e.g. one that loads from GitHub directly, this would result
in error.

There are no more such errors in this repo. I've used this shell script to
check: https://gist.github.com/sio/aa1520fcdc85a012ca3670f9bb39702b